### PR TITLE
Log websocket extension headers.

### DIFF
--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -61,6 +61,10 @@ class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
             return ["Forbidden"]
 
         self.environ["signature_validated"] = True
+
+        LOG.info('Sec-WebSocket-Extensions Headers: %r',
+                 self.headers.get('Sec-WebSocket-Extensions'))
+
         return super(WebSocketHandler, self).upgrade_connection()
 
 


### PR DESCRIPTION
👓 @spladug 

This should only be necessary temporarily until we get
a sense of what browsers are sending.  For this reason,
I'm opting for just logging here instead of creating a
config variable since it's such a narrow use case.