### PR TITLE
Add compression.

### DIFF
--- a/reddit_service_websockets/dispatcher.py
+++ b/reddit_service_websockets/dispatcher.py
@@ -35,10 +35,10 @@ COMPRESSOR = compressobj(7, DEFLATED, -MAX_WBITS)
 #
 #     http://stackoverflow.com/a/9151421/720638
 #
-# 1440 - common MTU size
+# 1500 - common MTU size
 # 60 - TCP max header size
 # 60 - IP max header size
-MIN_COMPRESS_SIZE = 1400 - 60 - 60
+MIN_COMPRESS_SIZE = 1500 - 60 - 60
 
 
 Message = namedtuple('Message', ['compressed', 'raw', 'percent_compressed'])

--- a/reddit_service_websockets/dispatcher.py
+++ b/reddit_service_websockets/dispatcher.py
@@ -62,8 +62,10 @@ class MessageDispatcher(object):
         consumers = self.consumers.get(namespace, [])
 
         # Compress the message
-        compressed = make_compressed_frame(message, COMPRESSOR) \
-            if len(message) >= MIN_COMPRESS_SIZE else None
+        if len(message) >= MIN_COMPRESS_SIZE:
+            compressed = make_compressed_frame(message, COMPRESSOR)
+        else:
+            compressed = None
         message = Message(
             compressed=compressed,
             raw=message,

--- a/reddit_service_websockets/dispatcher.py
+++ b/reddit_service_websockets/dispatcher.py
@@ -26,7 +26,7 @@ from .patched_websocket import make_compressed_frame
 COMPRESSOR = compressobj(7, DEFLATED, -MAX_WBITS)
 
 
-Message = namedtuple('Message', ['compressed', 'raw'])
+Message = namedtuple('Message', ['compressed', 'raw', 'percent_compressed'])
 
 
 def _walk_namespace_hierarchy(namespace):
@@ -48,7 +48,11 @@ class MessageDispatcher(object):
 
         # Compress the message
         compressed = make_compressed_frame(message, COMPRESSOR)
-        message = Message(compressed=compressed, raw=message)
+        message = Message(
+            compressed=compressed,
+            raw=message,
+            percent_compressed=1 - float(len(compressed))/float(len(message)),
+        )
 
         with self.metrics.timer("dispatch"):
             for consumer in consumers:

--- a/reddit_service_websockets/dispatcher.py
+++ b/reddit_service_websockets/dispatcher.py
@@ -1,8 +1,32 @@
+from collections import namedtuple
 import posixpath
 import random
+from zlib import (
+    compressobj,
+    DEFLATED,
+    MAX_WBITS,
+)
 
 import gevent
 import gevent.queue
+
+from .patched_websocket import make_compressed_frame
+
+
+# See http://www.zlib.net/manual.html#Advanced for details:
+#
+#     "windowBits can also be -8..-15 for raw deflate"
+#
+# Also see http://stackoverflow.com/a/22311297/720638
+#
+# We use a single global compressor to save on memory overhead, at the expense
+# of compression efficiency (since we cannot maintain a per-connection context
+# window).
+
+COMPRESSOR = compressobj(7, DEFLATED, -MAX_WBITS)
+
+
+Message = namedtuple('Message', ['compressed', 'raw'])
 
 
 def _walk_namespace_hierarchy(namespace):
@@ -21,6 +45,10 @@ class MessageDispatcher(object):
 
     def on_message_received(self, namespace, message):
         consumers = self.consumers.get(namespace, [])
+
+        # Compress the message
+        compressed = make_compressed_frame(message, COMPRESSOR)
+        message = Message(compressed=compressed, raw=message)
 
         with self.metrics.timer("dispatch"):
             for consumer in consumers:

--- a/reddit_service_websockets/dispatcher.py
+++ b/reddit_service_websockets/dispatcher.py
@@ -41,7 +41,7 @@ COMPRESSOR = compressobj(7, DEFLATED, -MAX_WBITS)
 MIN_COMPRESS_SIZE = 1500 - 60 - 60
 
 
-Message = namedtuple('Message', ['compressed', 'raw', 'percent_compressed'])
+Message = namedtuple('Message', ['compressed', 'raw'])
 
 
 def _walk_namespace_hierarchy(namespace):
@@ -66,12 +66,7 @@ class MessageDispatcher(object):
             compressed = make_compressed_frame(message, COMPRESSOR)
         else:
             compressed = None
-        message = Message(
-            compressed=compressed,
-            raw=message,
-            percent_compressed=(1 - float(len(compressed))/float(len(message)))
-                                if compressed is not None else 0,
-        )
+        message = Message(compressed=compressed, raw=message)
 
         with self.metrics.timer("dispatch"):
             for consumer in consumers:

--- a/reddit_service_websockets/patched_websocket.py
+++ b/reddit_service_websockets/patched_websocket.py
@@ -1,0 +1,124 @@
+"""
+This module patches a few core functions to add compression capabilities,
+since gevent-websocket does not appear to be maintained anymore.
+"""
+from socket import error
+from zlib import (
+    decompressobj,
+    MAX_WBITS,
+    Z_FULL_FLUSH,
+)
+
+from geventwebsocket.exceptions import (
+    ProtocolError,
+    WebSocketError,
+)
+from geventwebsocket.websocket import (
+    MSG_ALREADY_CLOSED,
+    MSG_CLOSED,
+    MSG_SOCKET_DEAD,
+    Header,
+    WebSocket,
+)
+
+
+DECOMPRESSOR = decompressobj(-MAX_WBITS)
+
+
+def _encode_bytes(text):
+    if isinstance(text, str):
+        return text
+
+    if not isinstance(text, unicode):
+        text = unicode(text or '')
+
+    return text.encode('utf-8')
+
+
+def make_compressed_frame(message, compressor):
+    """
+    Generates header and a compressed message which can then be used on any
+    websocket connection where `no_context_takeover` has been negotiated.
+    This prevents the need to re-compress a broadcast-style message for every
+    websocket connection.
+
+    `compressor` is a zlib compressor object.
+    """
+    binary = not isinstance(message, (str, unicode))
+    opcode = WebSocket.OPCODE_BINARY if binary else WebSocket.OPCODE_TEXT
+    if binary:
+        message = str(message)
+    else:
+        message = _encode_bytes(message)
+    message = compressor.compress(message)
+    # We use Z_FULL_FLUSH (rather than Z_SYNC_FLUSH) here when
+    # server_no_context_takeover has been passed, to reset the context at
+    # the end of every frame.  Patches to the actual gevent-websocket
+    # library should probably be able to support both.
+    message += compressor.flush(Z_FULL_FLUSH)
+    # See https://tools.ietf.org/html/rfc7692#page-19
+    if message.endswith('\x00\x00\xff\xff'):
+        message = message[:-4]
+
+    # Generate header.  The RSV0 bit indicates the payload is compressed.
+    flags = Header.RSV0_MASK
+    header = Header.encode_header(
+        fin=True, opcode=opcode, mask='', length=len(message), flags=flags)
+
+    return header + message
+
+
+def send_raw_frame(websocket, raw_message):
+    """
+    `raw_message` includes both the header and the encoded message.
+    """
+    try:
+        websocket.raw_write(raw_message)
+    except error:
+        websocket.current_app.on_close(MSG_SOCKET_DEAD)
+        raise WebSocketError(MSG_SOCKET_DEAD)
+
+
+def read_frame(websocket):
+    # Patched `read_frame` method that supports decompression
+
+    header = Header.decode_header(websocket.stream)
+
+    # Start patched lines
+    compressed = header.flags & header.RSV0_MASK
+    if compressed:
+        header.flags &= ~header.RSV0_MASK
+    # End patched lines
+
+    if header.flags:
+        raise ProtocolError
+
+    if not header.length:
+        return header, ''
+
+    try:
+        payload = websocket.raw_read(header.length)
+    except error:
+        payload = ''
+    except Exception:
+
+        # Start patched lines
+        raise WebSocketError('Could not read payload')
+        # End patched lines
+
+    if len(payload) != header.length:
+        raise WebSocketError('Unexpected EOF reading frame payload')
+
+    if header.mask:
+        payload = header.unmask_payload(payload)
+
+    # Start patched lines
+    if compressed:
+        payload = ''.join((
+            DECOMPRESSOR.decompress(payload),
+            DECOMPRESSOR.decompress('\0\0\xff\xff'),
+            DECOMPRESSOR.flush(),
+        ))
+    # End patched lines
+
+    return header, payload

--- a/reddit_service_websockets/patched_websocket.py
+++ b/reddit_service_websockets/patched_websocket.py
@@ -14,8 +14,6 @@ from geventwebsocket.exceptions import (
     WebSocketError,
 )
 from geventwebsocket.websocket import (
-    MSG_ALREADY_CLOSED,
-    MSG_CLOSED,
     MSG_SOCKET_DEAD,
     Header,
     WebSocket,

--- a/reddit_service_websockets/patched_websocket.py
+++ b/reddit_service_websockets/patched_websocket.py
@@ -37,6 +37,8 @@ def _encode_bytes(text):
 
 def make_compressed_frame(message, compressor):
     """
+    Make a compressed websocket frame from a message and compressor.
+
     Generates header and a compressed message which can then be used on any
     websocket connection where `no_context_takeover` has been negotiated.
     This prevents the need to re-compress a broadcast-style message for every

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -19,10 +19,8 @@ WebSocket.read_frame = patched_read_frame
 
 
 def send_metrics_histogram(metrics_client, name, value):
-    """
-    Counters won't give us percentile information, so we abuse timers
-    instead.
-    """
+    # Counters won't give us percentile information, so we abuse timers
+    # instead.
     timer_name = b".".join(node.strip(b".") for node in (
         metrics_client.namespace,
         name.encode("ascii")

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -4,11 +4,18 @@ import urlparse
 import gevent
 import geventwebsocket
 import geventwebsocket.handler
+from geventwebsocket.websocket import WebSocket
 
 from baseplate.crypto import MessageSigner, SignatureError
 
+from .patched_websocket import read_frame as patched_read_frame
+from .patched_websocket import send_raw_frame
+
 
 LOG = logging.getLogger(__name__)
+
+
+WebSocket.read_frame = patched_read_frame
 
 
 class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
@@ -61,7 +68,42 @@ class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
             return ["Forbidden"]
 
         self.environ["signature_validated"] = True
+
+        # Check if compression is supported.  The RFC explanation for the
+        # variations on what is accepted here is convoluted, so we'll just
+        # stick with the happy case:
+        #
+        #    https://tools.ietf.org/html/rfc6455#page-48
+        #
+        # Worst case scenario, we fall back to not compressing.
+        extensions = self.environ.get('HTTP_SEC_WEBSOCKET_EXTENSIONS')
+        extensions = {extension.split(";")[0].strip()
+                      for extension in extensions.split(",")}
+        self.environ["supports_compression"] = \
+            "permessage-deflate" in extensions
+
         return super(WebSocketHandler, self).upgrade_connection()
+
+    def start_response(self, status, headers, exc_info=None):
+        # Ideally, this would probably go in `upgrade_connection`, but we have
+        # no way to modify the headers there without duplicating the logic of
+        # the entire method.  This is a much smaller entry point.
+        # Ideally, geventwebsocket would just support this stuff.
+
+        if self.environ["supports_compression"]:
+
+            # {client,server}_no_context_takeover prevents compression context
+            # from being used across frames.  This is necessary so that we
+            # don't have to maintain a separate compressor for every connection
+            # that's made, which would be a large memory footprint.  This also
+            # lets us compress a message once and send to all clients, saving
+            # on CPU electrons.
+            headers.append(("Sec-WebSocket-Extensions",
+                            "permessage-deflate; server_no_context_takeover; "
+                            "client_no_context_takeover"))
+
+        return super(WebSocketHandler, self).start_response(
+            status, headers, exc_info=exc_info)
 
 
 class SocketServer(object):
@@ -91,13 +133,17 @@ class SocketServer(object):
         assert environ["signature_validated"]
 
         namespace = environ["PATH_INFO"]
-        dispatcher = gevent.spawn(self._pump_dispatcher, namespace, websocket)
+
+        dispatcher = gevent.spawn(
+            self._pump_dispatcher, namespace, websocket,
+            supports_compression=environ["supports_compression"])
 
         try:
             self.metrics.counter("conn.connected").increment()
             self._send_message("connect", {"namespace": namespace})
             while True:
                 message = websocket.receive()
+                LOG.debug('message received: %r', message)
                 if message is None:
                     break
         except geventwebsocket.WebSocketError as e:
@@ -111,9 +157,13 @@ class SocketServer(object):
         if self.status_publisher:
             self.status_publisher("websocket.%s" % key, value)
 
-    def _pump_dispatcher(self, namespace, websocket):
-        for msg in self.dispatcher.listen(namespace, max_timeout=self.ping_interval):
+    def _pump_dispatcher(self, namespace, websocket, supports_compression):
+        for msg in self.dispatcher.listen(
+                namespace, max_timeout=self.ping_interval):
             if msg is not None:
-                websocket.send(msg)
+                if supports_compression:
+                    send_raw_frame(websocket, msg.compressed)
+                else:
+                    websocket.send(msg.raw)
             else:
                 websocket.send_frame("", websocket.OPCODE_PING)

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -18,17 +18,6 @@ LOG = logging.getLogger(__name__)
 WebSocket.read_frame = patched_read_frame
 
 
-def send_metrics_histogram(metrics_client, name, value):
-    # Counters won't give us percentile information, so we abuse timers
-    # instead.
-    timer_name = b".".join(node.strip(b".") for node in (
-        metrics_client.namespace,
-        name.encode("ascii")
-    ))
-    serialized = timer_name + ":{:g}|ms".format(value).encode()
-    metrics_client.transport.send(serialized)
-
-
 class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
     def read_request(self, raw_requestline):
         retval = super(WebSocketHandler, self).read_request(raw_requestline)
@@ -176,16 +165,6 @@ class SocketServer(object):
         for msg in self.dispatcher.listen(namespace, max_timeout=self.ping_interval):
             if msg is not None:
                 if supports_compression and msg.compressed is not None:
-
-                    # Compressed size can actually go *above* original size
-                    # because of compression headers.  In this case, the
-                    # percentage will come out negative, which is not a valid
-                    # value for timers per the statsd spec.
-                    send_metrics_histogram(
-                        self.metrics,
-                        "message.percent_compressed",
-                        max(msg.percent_compressed, 0))
-
                     send_raw_frame(websocket, msg.compressed)
                 else:
                     websocket.send(msg.raw)

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -173,8 +173,7 @@ class SocketServer(object):
             self.status_publisher("websocket.%s" % key, value)
 
     def _pump_dispatcher(self, namespace, websocket, supports_compression):
-        for msg in self.dispatcher.listen(
-                namespace, max_timeout=self.ping_interval):
+        for msg in self.dispatcher.listen(namespace, max_timeout=self.ping_interval):
             if msg is not None:
                 if supports_compression:
 

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -18,6 +18,19 @@ LOG = logging.getLogger(__name__)
 WebSocket.read_frame = patched_read_frame
 
 
+def send_metrics_histogram(metrics_client, name, value):
+    """
+    Counters won't give us percentile information, so we abuse timers
+    instead.
+    """
+    timer_name = b".".join(node.strip(b".") for node in (
+        metrics_client.namespace,
+        name.encode("ascii")
+    ))
+    serialized = timer_name + ":{:g}|ms".format(value).encode()
+    metrics_client.transport.send(serialized)
+
+
 class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
     def read_request(self, raw_requestline):
         retval = super(WebSocketHandler, self).read_request(raw_requestline)
@@ -101,6 +114,10 @@ class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
             headers.append(("Sec-WebSocket-Extensions",
                             "permessage-deflate; server_no_context_takeover; "
                             "client_no_context_takeover"))
+            self.application.metrics.counter(
+                "compression.permessage-deflate").increment()
+        else:
+            self.application.metrics.counter("compression.none").increment()
 
         return super(WebSocketHandler, self).start_response(
             status, headers, exc_info=exc_info)
@@ -162,6 +179,16 @@ class SocketServer(object):
                 namespace, max_timeout=self.ping_interval):
             if msg is not None:
                 if supports_compression:
+
+                    # Compressed size can actually go *above* original size
+                    # because of compression headers.  In this case, the
+                    # percentage will come out negative, which is not a valid
+                    # value for timers per the statsd spec.
+                    send_metrics_histogram(
+                        self.metrics,
+                        "message.percent_compressed",
+                        max(msg.percent_compressed, 0))
+
                     send_raw_frame(websocket, msg.compressed)
                 else:
                     websocket.send(msg.raw)

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -175,7 +175,7 @@ class SocketServer(object):
     def _pump_dispatcher(self, namespace, websocket, supports_compression):
         for msg in self.dispatcher.listen(namespace, max_timeout=self.ping_interval):
             if msg is not None:
-                if supports_compression:
+                if supports_compression and msg.compressed is not None:
 
                     # Compressed size can actually go *above* original size
                     # because of compression headers.  In this case, the

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -85,11 +85,6 @@ class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
         return super(WebSocketHandler, self).upgrade_connection()
 
     def start_response(self, status, headers, exc_info=None):
-        # Ideally, this would probably go in `upgrade_connection`, but we have
-        # no way to modify the headers there without duplicating the logic of
-        # the entire method.  This is a much smaller entry point.
-        # Ideally, geventwebsocket would just support this stuff.
-
         if self.environ["supports_compression"]:
 
             # {client,server}_no_context_takeover prevents compression context

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -56,6 +56,19 @@ class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
 
         app = self.application
 
+        # Check if compression is supported.  The RFC explanation for the
+        # variations on what is accepted here is convoluted, so we'll just
+        # stick with the happy case:
+        #
+        #    https://tools.ietf.org/html/rfc6455#page-48
+        #
+        # Worst case scenario, we fall back to not compressing.
+        extensions = self.environ.get('HTTP_SEC_WEBSOCKET_EXTENSIONS', '')
+        extensions = {extension.split(";")[0].strip()
+                      for extension in extensions.split(",")}
+        self.environ["supports_compression"] = \
+            "permessage-deflate" in extensions
+
         try:
             namespace = self.environ["PATH_INFO"]
             query_string = self.environ["QUERY_STRING"]
@@ -69,23 +82,10 @@ class WebSocketHandler(geventwebsocket.handler.WebSocketHandler):
 
         self.environ["signature_validated"] = True
 
-        # Check if compression is supported.  The RFC explanation for the
-        # variations on what is accepted here is convoluted, so we'll just
-        # stick with the happy case:
-        #
-        #    https://tools.ietf.org/html/rfc6455#page-48
-        #
-        # Worst case scenario, we fall back to not compressing.
-        extensions = self.environ.get('HTTP_SEC_WEBSOCKET_EXTENSIONS')
-        extensions = {extension.split(";")[0].strip()
-                      for extension in extensions.split(",")}
-        self.environ["supports_compression"] = \
-            "permessage-deflate" in extensions
-
         return super(WebSocketHandler, self).upgrade_connection()
 
     def start_response(self, status, headers, exc_info=None):
-        if self.environ["supports_compression"]:
+        if self.environ.get("supports_compression"):
 
             # {client,server}_no_context_takeover prevents compression context
             # from being used across frames.  This is necessary so that we
@@ -135,7 +135,7 @@ class SocketServer(object):
 
         dispatcher = gevent.spawn(
             self._pump_dispatcher, namespace, websocket,
-            supports_compression=environ["supports_compression"])
+            supports_compression=environ.get("supports_compression"))
 
         try:
             self.metrics.counter("conn.connected").increment()


### PR DESCRIPTION
👓 @spladug 

I'm erring now on the side of not doing the fork of `gevent-websocket`, just because the way we are doing things here with a single compressor and decompressor means the resulting interface / code will end up being a hack regardless.  Let me know what you think.

Stats stuff is split into another commit just because it's kind of hacky, and we might want to do some of it differently.  I chose to do `percent_compressed` versus something like `bytes_saved` since:

    10,000 -> 1,000 = 9000 bytes saved @ 90% efficiency

While

    100,000 - 91,000 = 9000 bytes saved @ ~9% efficiency

It seems like percentage gives the picture we want.