### PR TITLE
Add signal handling for USR2 to trigger quiescing.

### DIFF
--- a/reddit_service_websockets/app.py
+++ b/reddit_service_websockets/app.py
@@ -1,3 +1,5 @@
+import signal
+
 import gevent
 
 from baseplate import config, make_metrics_client

--- a/reddit_service_websockets/app.py
+++ b/reddit_service_websockets/app.py
@@ -51,6 +51,15 @@ def make_app(raw_config):
         conn_shed_rate=cfg.web.conn_shed_rate,
     )
 
+    # register SIGUSR2 to trigger app quiescing,
+    #  useful if app processes are behind
+    #  a process manager like einhorn.
+    def _handle_quiesce_signal(_, frame):
+        app._quiesce({}, bypass_auth=True)
+
+    signal.signal(signal.SIGUSR2, _handle_quiesce_signal)
+    signal.siginterrupt(signal.SIGUSR2, False)
+
     source.message_handler = dispatcher.on_message_received
     app.status_publisher = source.send_message
 

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -129,15 +129,6 @@ class SocketServer(object):
         self.quiesced = False
         self.connections = set()
 
-        # register SIGUSR2 to trigger quiescing,
-        #  useful if server processes are behind
-        #  a process manager like einhorn.
-        def _handle_quiesce_signal(_, frame):
-            self._quiesce({}, bypass_auth=True)
-
-        signal.signal(signal.SIGUSR2, _handle_quiesce_signal)
-        signal.siginterrupt(signal.SIGUSR2, False)
-
     def __call__(self, environ, start_response):
         path_info = environ["PATH_INFO"]
         req_method = environ['REQUEST_METHOD']

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -1,6 +1,5 @@
 import base64
 import logging
-import signal
 import urlparse
 
 import gevent


### PR DESCRIPTION
This adds quiescing on signal handling of `USR2` in the event that the server process is behind something like Einhorn. 

I can't think of any reason to keep the HTTP endpoint stuff around, I'll probably rip that out in a separate commit. 

:eyeglasses: @spladug 