### PR TITLE
Create manhole when SIGUSR1 received.

### DIFF
--- a/reddit_service_websockets/app.py
+++ b/reddit_service_websockets/app.py
@@ -3,10 +3,14 @@ import signal
 import gevent
 
 from baseplate import config, make_metrics_client
+import manhole
 
 from .dispatcher import MessageDispatcher
 from .socketserver import SocketServer
 from .source import MessageSource
+
+
+manhole.install(oneshot_on='USR1')
 
 
 CONFIG_SPEC = {

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
         "gevent-websocket",
         "haigha",
         "baseplate",
+        "manhole",
     ],
 )


### PR DESCRIPTION
👓 @spladug @ckwang8128 

Previously, a manhole socket was being created for every process on
startup.  This worked fine in development, but did not seem to play well
with einhorn (or something) in production.

Instead, we'll wait until SIGUSR1 is received for a particular process to
create a manhole socket only for that process.  This will still cause that
particular process to stop, but in the case of the OOM issue we are trying to
solve, it is only a matter of time before those connections are dropped
anyway.  This seems like a reasonable tradeoff, as it will still the service
to operate normally until the manhole is invoked.