### PR TITLE
Shut down websocket service on USR2 signal after quiesce.

### DIFF
--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import sys
 import urlparse
 
 import gevent
@@ -227,6 +228,11 @@ class SocketServer(object):
                                    self._shed_connections,
                                    [conns.pop() for j in xrange(num_conns)])
 
+            # Terminate the service after shedding
+            termination_delay_secs = 10
+            gevent.spawn_later(shed_delay_secs + cur_iter_sec +
+                               termination_delay_secs,
+                               self._shutdown)
 
     def _shed_connections(self, connections):
         LOG.debug("closing %d connections", len(connections))
@@ -236,6 +242,10 @@ class SocketServer(object):
             except geventwebsocket.WebSocketError:
                 # Connection might already be closed or dead
                 pass
+
+    def _shutdown(self):
+        LOG.info("Shutting down.")
+        sys.exit()
 
     def _send_message(self, key, value):
         if self.status_publisher:

--- a/tests/unit/socketserver_tests.py
+++ b/tests/unit/socketserver_tests.py
@@ -3,7 +3,11 @@ import unittest
 
 import geventwebsocket.websocket
 from geventwebsocket.websocket import WebSocket
-from mock import Mock, patch
+from mock import (
+    call,
+    Mock,
+    patch,
+)
 
 from reddit_service_websockets.socketserver import (
     SocketServer,
@@ -73,6 +77,13 @@ class SocketServerTests(unittest.TestCase):
         self.server.connections = set([mock_conn])
 
         self.server._quiesce(environ)
-        # 31 -> shed_delay_seconds + 1 second for iteration
-        gevent_patch.assert_called_with(31, self.server._shed_connections, [mock_conn])
+
+        calls = [
+            # 31 -> shed_delay_seconds + 1 second for iteration
+            call(31, self.server._shed_connections, [mock_conn]),
+            # 41 -> shed_delay_seconds + 1 second for iteration +
+            #       termination_delay_secs
+            call(41, self.server._shutdown),
+        ]
+        gevent_patch.assert_has_calls(calls)
 


### PR DESCRIPTION
This adds an explicit service shutdown  after connection
quiescing to accommodate USR2 signals from Einhorn.
Einhorn sends a USR2 signal as part of its app reloading process ("Once the new workers have been spawned, Einhorn will send each old worker a SIGUSR2. SIGUSR2 should be interpreted as a request for a graceful shutdown." - https://github.com/stripe/einhorn) 
The websocket service catches SIGUSR2 and goes into a quiesced state
but never completely shuts down, causing latent websocket service processes
to remain after an Einhorn reload.

:eyeglasses: @dellis23 @spladug  (sorry for the weekend ping) 