### PR TITLE
Add Sentry integration, version 2

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -34,6 +34,9 @@ metrics.endpoint =
 
 secrets.path = example_secrets.json
 
+sentry.dsn =
+sentry.environment = dev
+
 [server:main]
 factory = baseplate.server.wsgi
 handler = reddit_service_websockets.socketserver:WebSocketHandler

--- a/reddit_service_websockets/app.py
+++ b/reddit_service_websockets/app.py
@@ -6,6 +6,7 @@ import manhole
 from baseplate import (
     config,
     metrics_client_from_config,
+    error_reporter_from_config,
 )
 from baseplate.secrets import secrets_store_from_config
 
@@ -44,6 +45,7 @@ def make_app(raw_config):
     cfg = config.parse_config(raw_config, CONFIG_SPEC)
 
     metrics_client = metrics_client_from_config(raw_config)
+    error_reporter = error_reporter_from_config(raw_config, __name__)
     secrets = secrets_store_from_config(raw_config)
 
     dispatcher = MessageDispatcher(metrics=metrics_client)
@@ -56,6 +58,7 @@ def make_app(raw_config):
         metrics=metrics_client,
         dispatcher=dispatcher,
         secrets=secrets,
+        error_reporter=error_reporter,
         ping_interval=cfg.web.ping_interval,
         admin_auth=cfg.web.admin_auth,
         conn_shed_rate=cfg.web.conn_shed_rate,

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -139,15 +139,17 @@ class SocketServer(object):
         except (KeyboardInterrupt, SystemExit):
             raise
         except:
-            self.error_reporter.http_context({
-                'method': environ.get('REQUEST_METHOD'),
-                'url': get_current_url(environ, strip_querystring=True),
-                'query_string': environ.get('QUERY_STRING'),
-                'headers': dict(get_headers(environ)),
-                'env': dict(get_environ(environ)),
-            })
-            self.error_reporter.captureException()
-            self.error_reporter.context.clear()
+            if self.error_reporter:
+                self.error_reporter.http_context({
+                    'method': environ.get('REQUEST_METHOD'),
+                    'url': get_current_url(environ, strip_querystring=True),
+                    'query_string': environ.get('QUERY_STRING'),
+                    'headers': dict(get_headers(environ)),
+                    'env': dict(get_environ(environ)),
+                })
+                self.error_reporter.captureException()
+                self.error_reporter.context.clear()
+            raise
 
     def _handle_request(self, environ, start_response):
         path_info = environ["PATH_INFO"]

--- a/reddit_service_websockets/socketserver.py
+++ b/reddit_service_websockets/socketserver.py
@@ -8,6 +8,7 @@ import geventwebsocket.handler
 from geventwebsocket.websocket import WebSocket
 
 from baseplate.crypto import validate_signature, SignatureError
+from raven.utils.wsgi import get_current_url, get_headers, get_environ
 
 from .patched_websocket import read_frame as patched_read_frame
 from .patched_websocket import send_raw_frame
@@ -116,6 +117,7 @@ class SocketServer(object):
     def __init__(self, metrics,
                  dispatcher,
                  secrets,
+                 error_reporter,
                  ping_interval,
                  admin_auth,
                  conn_shed_rate,
@@ -123,6 +125,7 @@ class SocketServer(object):
         self.metrics = metrics
         self.dispatcher = dispatcher
         self.secrets = secrets
+        self.error_reporter = error_reporter
         self.ping_interval = ping_interval
         self.admin_auth = admin_auth
         self.shed_rate_per_sec = conn_shed_rate
@@ -131,6 +134,22 @@ class SocketServer(object):
         self.connections = set()
 
     def __call__(self, environ, start_response):
+        try:
+            return self._handle_request(environ, start_response)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.error_reporter.http_context({
+                'method': environ.get('REQUEST_METHOD'),
+                'url': get_current_url(environ, strip_querystring=True),
+                'query_string': environ.get('QUERY_STRING'),
+                'headers': dict(get_headers(environ)),
+                'env': dict(get_environ(environ)),
+            })
+            self.error_reporter.captureException()
+            self.error_reporter.context.clear()
+
+    def _handle_request(self, environ, start_response):
         path_info = environ["PATH_INFO"]
         req_method = environ['REQUEST_METHOD']
 

--- a/tests/functional/socketserver_tests.py
+++ b/tests/functional/socketserver_tests.py
@@ -16,6 +16,7 @@ class WebsocketServiceTests(unittest.TestCase):
             metrics=Mock(),
             dispatcher=Mock(),
             secrets=secrets,
+            error_reporter=None,
             ping_interval=1,
             admin_auth='test-auth',
             conn_shed_rate=5,

--- a/tests/unit/socketserver_tests.py
+++ b/tests/unit/socketserver_tests.py
@@ -23,6 +23,7 @@ class SocketServerTests(unittest.TestCase):
             metrics=Mock(),
             dispatcher=Mock(),
             secrets=secrets,
+            error_reporter=None,
             ping_interval=1,
             admin_auth='test-auth',
             conn_shed_rate=5,


### PR DESCRIPTION
The previous attempt used the raven-provided middleware. Unfortunately,
we have to run code in the wsgi handler context as well and it gets
application state from the application so things got rather complex when
the application was wrapped in a middleware. This is a less invasive but
more manual way of adding raven into the mix.