### PR TITLE
Connect to correct rabbitmq hostname.

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -2,7 +2,7 @@
 factory = reddit_service_websockets.app:make_app
 
 ; configuration for connecting to the amqp broker
-amqp.endpoint = localhost:5672
+amqp.endpoint = rabbit.local:5672
 amqp.vhost = /
 amqp.username = guest
 amqp.password = guest


### PR DESCRIPTION
👓 @spladug @bsimpson63 

2b415bb6b89e42dd283065ca239488dfc88fae74 in reddit-public changes the
address we're binding rabbitmq to, so we need that to match here.

Alternative commit title: "fix broken comment trees in r2 dev."  Long
story short, without the "sutro" exchange being created, r2 tries to
publish orangered notifications to an exchange that doesn't exist.  This
appears to go fine, but any future messages published on that connection
are just... dropped.  Silently.  You can probably guess how difficult it
was to figure out these two issues were related.